### PR TITLE
fix: Fix Active Highlighting for Governance Tab

### DIFF
--- a/src/layouts/NavItem.tsx
+++ b/src/layouts/NavItem.tsx
@@ -14,9 +14,9 @@ interface Props {
 const NavItem = ({ name, to, icon, submenu }: Props) => {
   const { pathname } = useLocation()
   const active =
-    to === '/'
-      ? pathname === '/'
-      : pathname.startsWith(to) ||
+    pathname === '/'
+      ? to === '/'
+      : to.startsWith(pathname) ||
         !!submenu?.some((p) => pathname.startsWith(p))
 
   return (


### PR DESCRIPTION
A fix to ensure that the Governance tab shows proper "active" styling.

Before:
![image](https://user-images.githubusercontent.com/46784573/123589625-7b0ffe00-d824-11eb-9d11-ef7195d02943.png)

After:
![image](https://user-images.githubusercontent.com/46784573/123589665-8400cf80-d824-11eb-96dd-f1bd3a426c77.png)
