### PR TITLE
fix: Use `from` when reading from the whitelist on swaps.

### DIFF
--- a/src/post/hooks/wallet/useSwap.ts
+++ b/src/post/hooks/wallet/useSwap.ts
@@ -435,13 +435,16 @@ export default (user: User, actives: string[]): PostPage<SwapUI> => {
           title: t('Post:Swap:Available balance'),
           display: format.display(
             { amount: maxAmount, denom: from },
-            whitelist?.[to]?.decimals,
+            whitelist?.[from]?.decimals,
             undefined,
             whitelist
           ),
           attrs: {
             onClick: () =>
-              setValue('input', toInput(maxAmount, whitelist?.[to]?.decimals)),
+              setValue(
+                'input',
+                toInput(maxAmount, whitelist?.[from]?.decimals)
+              ),
           },
         },
     expectedPrice: !gt(simulated, 0)


### PR DESCRIPTION
Before this change: 

<img width="496" alt="Screen Shot 2021-11-04 at 12 48 40 PM" src="https://user-images.githubusercontent.com/142006/140392452-b70cd40a-3fce-49f9-8278-8e14f1cff5ed.png">


After this change: 

<img width="378" alt="Screen Shot 2021-11-04 at 12 49 30 PM" src="https://user-images.githubusercontent.com/142006/140392542-225fd3f4-3983-4b2e-a164-62d4ba56c87a.png">

