### PR TITLE
fix: provide token precision from whitelist if defined for tx history.

### DIFF
--- a/src/pages/hooks/txs/ParseTxText.tsx
+++ b/src/pages/hooks/txs/ParseTxText.tsx
@@ -26,7 +26,8 @@ const IBCBaseDenom = ({ children: unit }: { children: string }) => {
 const Coin = ({ children: coin }: { children: string }) => {
   const { whitelist } = useWhitelist()
   const { amount, token } = splitTokenText(coin)
-  const value = format.amount(amount)
+  /* Load token precision from the whitelist if defined. amount defaults to 6. */
+  const value = format.amount(amount, whitelist && whitelist[token]?.decimals)
 
   const unit = is.ibcDenom(token) ? (
     <IBCBaseDenom>{token}</IBCBaseDenom>


### PR DESCRIPTION
Another fix for decimal display related to tokens with 8 decimals supported. 

**Before**

![local terra money_3000_history (2)](https://user-images.githubusercontent.com/142006/140578281-6bb188ad-960d-4d87-bce1-0a52e6e08bf1.png)


**After**

![local terra money_3000_history (1)](https://user-images.githubusercontent.com/142006/140578202-e162b3b5-00d1-4f98-a959-cde46bb4b236.png)


I only purchased 0.66 Orion.