### PR TITLE
Add TNS support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@terra-money/react-widget": "^0.1.3",
         "@terra-money/terra.js": "^2.1.19",
         "@terra-money/wallet-provider": "^2.3.0",
+        "@tns-money/tns.js": "^1.0.6",
         "@ungap/url-search-params": "^0.2",
         "ace-builds": "^1.4.12",
         "axios": "^0.21.1",
@@ -114,6 +115,43 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.4.16",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.16.tgz",
+      "integrity": "sha512-iF4zEYwvebkri0BZQyv8zfavPfVEafsK0wkOofa6eC2yZu50J18uTutKtC174rjHZ2eyxZ8tV7NvAPKRT+OtZw==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.0",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "~1.1.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apollo/client/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.15.8",
@@ -2059,6 +2097,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
       "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
     },
     "node_modules/@hapi/address": {
       "version": "2.1.4",
@@ -4032,9 +4078,9 @@
       }
     },
     "node_modules/@terra-money/terra.js": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-2.1.19.tgz",
-      "integrity": "sha512-6v4JMzG7TDpGAanyqosb0NBiwMIprggHCrU+ff5kbnZGhEdi58X7Swa+xfYDiH+fA5wgkM/3PvJH48T0fWDPmA==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-2.1.22.tgz",
+      "integrity": "sha512-6El+UdmOXGeX+4XJQU1yvZ5nexs7zfKqys7WYDjN5y10U7rGow/rzKuKIMPdDBF+M0njWJ6zYf+En6J0yqGq3w==",
       "dependencies": {
         "@terra-money/terra.proto": "^0.1.7",
         "axios": "^0.21.1",
@@ -4044,7 +4090,6 @@
         "bufferutil": "^4.0.3",
         "decimal.js": "^10.2.1",
         "jscrypto": "^1.0.1",
-        "long": "^4.0.0",
         "readable-stream": "^3.6.0",
         "secp256k1": "^4.0.2",
         "tmp": "^0.2.1",
@@ -4052,7 +4097,7 @@
         "ws": "^7.4.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@terra-money/terra.proto": {
@@ -4107,6 +4152,27 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+    },
+    "node_modules/@tns-money/tns.js": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@tns-money/tns.js/-/tns.js-1.0.6.tgz",
+      "integrity": "sha512-r5CMEmsEIYpH84OvehomhT4zzA1t1SxsjvhzYu47dXN4kpqyEuW39djbqy5uhHHUrrNb1wk/y0urlQ4eB/scTQ==",
+      "dependencies": {
+        "@apollo/client": "^3.4.16",
+        "cross-fetch": "^3.1.4",
+        "graphql": "^15.0.0",
+        "graphql-tag": "^2.12.5",
+        "json-to-graphql-query": "^2.1.0",
+        "keccak256": "^1.0.3",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@terra-money/terra.js": "^2.1.22"
+      }
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -4557,6 +4623,11 @@
       "version": "20.2.1",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
+    },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.28.4",
@@ -5065,6 +5136,54 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/context/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
+      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -7547,6 +7666,14 @@
         "node": ">=10.14",
         "npm": ">=6",
         "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dependencies": {
+        "node-fetch": "2.6.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -11356,6 +11483,25 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-tag/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "node_modules/growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -15148,6 +15294,11 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "optional": true
     },
+    "node_modules/json-to-graphql-query": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-2.1.0.tgz",
+      "integrity": "sha512-8BJP4Zx27jII6uyMfWRfnEKIP93GE9C+yolsoRKZ1nOT6HhQjaYcOzVvrqePAWog32+C62nF/N82c89YUEHLMQ=="
+    },
     "node_modules/json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -15188,6 +15339,29 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/keccak": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/keccak256": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.3.tgz",
+      "integrity": "sha512-EkF/4twuPm1V/gn75nejOUrKfDUJn87RMLzDWosXF3pXuOvesiSgX35GcmbqzdImCASEkE/WaklWGWSa+Ha5bQ==",
+      "dependencies": {
+        "bn.js": "^4.11.8",
+        "keccak": "^3.0.1"
       }
     },
     "node_modules/keyv": {
@@ -15467,6 +15641,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -16384,6 +16563,14 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -16899,6 +17086,15 @@
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "dependencies": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optimize-css-assets-webpack-plugin": {
@@ -22361,6 +22557,14 @@
         "boolbase": "~1.0.0"
       }
     },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -22995,6 +23199,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.3.tgz",
+      "integrity": "sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-invariant/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/ts-pnp": {
       "version": "1.2.0",
@@ -25701,6 +25921,20 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "dependencies": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
     }
   },
   "dependencies": {
@@ -25710,6 +25944,32 @@
       "integrity": "sha512-xUDO0njY31ye+dNT8IwTOFc/84B6onNpDzq+CAaWwt46p8o3Y1DfDG5GX0kGu7Zb/2g9TyFydsawyTDQmbVg6g==",
       "requires": {
         "@terra-money/terra.js": "^2.0.14"
+      }
+    },
+    "@apollo/client": {
+      "version": "3.4.16",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.16.tgz",
+      "integrity": "sha512-iF4zEYwvebkri0BZQyv8zfavPfVEafsK0wkOofa6eC2yZu50J18uTutKtC174rjHZ2eyxZ8tV7NvAPKRT+OtZw==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.0",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "~1.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -27056,6 +27316,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
       "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
+    },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "requires": {}
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -28480,9 +28746,9 @@
       }
     },
     "@terra-money/terra.js": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-2.1.19.tgz",
-      "integrity": "sha512-6v4JMzG7TDpGAanyqosb0NBiwMIprggHCrU+ff5kbnZGhEdi58X7Swa+xfYDiH+fA5wgkM/3PvJH48T0fWDPmA==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/@terra-money/terra.js/-/terra.js-2.1.22.tgz",
+      "integrity": "sha512-6El+UdmOXGeX+4XJQU1yvZ5nexs7zfKqys7WYDjN5y10U7rGow/rzKuKIMPdDBF+M0njWJ6zYf+En6J0yqGq3w==",
       "requires": {
         "@terra-money/terra.proto": "^0.1.7",
         "axios": "^0.21.1",
@@ -28492,7 +28758,6 @@
         "bufferutil": "^4.0.3",
         "decimal.js": "^10.2.1",
         "jscrypto": "^1.0.1",
-        "long": "^4.0.0",
         "readable-stream": "^3.6.0",
         "secp256k1": "^4.0.2",
         "tmp": "^0.2.1",
@@ -28542,6 +28807,21 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
           "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
+      }
+    },
+    "@tns-money/tns.js": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@tns-money/tns.js/-/tns.js-1.0.6.tgz",
+      "integrity": "sha512-r5CMEmsEIYpH84OvehomhT4zzA1t1SxsjvhzYu47dXN4kpqyEuW39djbqy5uhHHUrrNb1wk/y0urlQ4eB/scTQ==",
+      "requires": {
+        "@apollo/client": "^3.4.16",
+        "cross-fetch": "^3.1.4",
+        "graphql": "^15.0.0",
+        "graphql-tag": "^2.12.5",
+        "json-to-graphql-query": "^2.1.0",
+        "keccak256": "^1.0.3",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21"
       }
     },
     "@tootallnate/once": {
@@ -28985,6 +29265,11 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
     },
+    "@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.28.4",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.4.tgz",
@@ -29398,6 +29683,51 @@
       "integrity": "sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==",
       "dev": true,
       "requires": {}
+    },
+    "@wry/context": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@wry/equality": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+      "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
+      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -31431,6 +31761,14 @@
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -34372,6 +34710,21 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
       "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw=="
     },
+    "graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -37153,6 +37506,11 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "optional": true
     },
+    "json-to-graphql-query": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-2.1.0.tgz",
+      "integrity": "sha512-8BJP4Zx27jII6uyMfWRfnEKIP93GE9C+yolsoRKZ1nOT6HhQjaYcOzVvrqePAWog32+C62nF/N82c89YUEHLMQ=="
+    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -37182,6 +37540,25 @@
       "requires": {
         "array-includes": "^3.1.2",
         "object.assign": "^4.1.2"
+      }
+    },
+    "keccak": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "keccak256": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.3.tgz",
+      "integrity": "sha512-EkF/4twuPm1V/gn75nejOUrKfDUJn87RMLzDWosXF3pXuOvesiSgX35GcmbqzdImCASEkE/WaklWGWSa+Ha5bQ==",
+      "requires": {
+        "bn.js": "^4.11.8",
+        "keccak": "^3.0.1"
       }
     },
     "keyv": {
@@ -37396,6 +37773,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -38127,6 +38509,11 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -38521,6 +38908,15 @@
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
           "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
         }
+      }
+    },
+    "optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "requires": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "optimize-css-assets-webpack-plugin": {
@@ -42834,6 +43230,11 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -43321,6 +43722,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+    },
+    "ts-invariant": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.3.tgz",
+      "integrity": "sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
     },
     "ts-pnp": {
       "version": "1.2.0",
@@ -45484,6 +45900,20 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "requires": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@terra-money/react-widget": "^0.1.3",
     "@terra-money/terra.js": "^2.1.19",
     "@terra-money/wallet-provider": "^2.3.0",
+    "@tns-money/tns.js": "^1.0.6",
     "@ungap/url-search-params": "^0.2",
     "ace-builds": "^1.4.12",
     "axios": "^0.21.1",

--- a/src/components/Field.module.scss
+++ b/src/components/Field.module.scss
@@ -14,3 +14,9 @@
   margin-top: 10px;
   text-align: right;
 }
+
+.helper {
+  opacity: 0.5;
+  margin-bottom: 5px;
+  font-size: 12px;
+}

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 const Field = ({ field, focus, onFocus, render, ...props }: Props) => {
   const { label, element, attrs, setValue, error } = field
-  const { copy, button, unit, options, ui } = field
+  const { copy, button, helper, unit, options, ui } = field
   const isCheckbox = ['checkbox', 'radio'].includes(attrs.type!)
   const className = isCheckbox ? 'form-check' : 'form-group'
 
@@ -63,6 +63,8 @@ const Field = ({ field, focus, onFocus, render, ...props }: Props) => {
       <label className="label" htmlFor={attrs.id}>
         {label}
       </label>
+
+      {helper && <div className={c(s.helper)}>{helper}</div>}
 
       {copy && (
         <Copy

--- a/src/hooks/useTns.ts
+++ b/src/hooks/useTns.ts
@@ -1,0 +1,46 @@
+import { isTnsName, NetworkName, TNS } from '@tns-money/tns.js'
+import _ from 'lodash'
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useCurrentChainName } from '../data/chain'
+
+export const useTns = () => {
+  const currentChainName = useCurrentChainName()
+  const { t } = useTranslation()
+
+  const [address, setAddress] = useState('')
+  const [isError, setIsError] = useState(false)
+
+  const resolveDebounced = useMemo(
+    () =>
+      _.debounce(async (name: string) => {
+        if (isTnsName(name)) {
+          const tns = new TNS({ network: currentChainName as NetworkName })
+
+          try {
+            const terraAddress = await tns.name(name).getTerraAddress()
+
+            if (terraAddress) {
+              setAddress(terraAddress)
+            } else {
+              setIsError(true)
+            }
+          } catch {}
+        }
+      }, 350),
+    [currentChainName]
+  )
+
+  return {
+    address,
+    resolve: useCallback(
+      (name: string) => {
+        setAddress('')
+        setIsError(false)
+        resolveDebounced(name)
+      },
+      [resolveDebounced]
+    ),
+    error: isError ? t('Common:TNS:This name has not yet been configured') : '',
+  }
+}

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -27,6 +27,10 @@
       "Log": "Diario"
     },
 
+    "TNS": {
+      "This name has not yet been configured": "Este nombre aún no se ha configurado"
+    },
+
     "Form": {
       "Optional": "Opcional",
       "Next": "Siguiente",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -27,6 +27,10 @@
       "Log": "Journal"
     },
 
+    "TNS": {
+      "This name has not yet been configured": "Ce nom n'a pas encore été configuré"
+    },
+
     "Form": {
       "Optional": "Optionel",
       "Next": "Suivant",

--- a/src/lang/pl.json
+++ b/src/lang/pl.json
@@ -27,6 +27,10 @@
       "Log": "Rejestr"
     },
 
+    "TNS": {
+      "This name has not yet been configured": "Ta nazwa nie została jeszcze ustawiona"
+    },
+
     "Form": {
       "Optional": "Opcjonalne",
       "Next": "Następne",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -27,6 +27,10 @@
       "Log": "Журнал"
     },
 
+    "TNS": {
+      "This name has not yet been configured": "Это имя еще не настроено"
+    },
+
     "Form": {
       "Optional": "По желанию",
       "Next": "Следующий",

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -27,6 +27,10 @@
       "Log": "记录"
     },
 
+    "TNS": {
+      "This name has not yet been configured": "此名称尚未配置"
+    },
+
     "Form": {
       "Optional": "可选项",
       "Next": "下一步",

--- a/src/types/common/form.ts
+++ b/src/types/common/form.ts
@@ -20,6 +20,7 @@ export interface Field<U = any> {
 
   error?: string
   copy?: string
+  helper?: string
   ui?: U
 
   /* post */


### PR DESCRIPTION
## Changes
- Introduce `helper` field on `Field` interface to show a subtle note about the resolved address.

![Screen_Shot_2564-11-08_at_17 21 56](https://user-images.githubusercontent.com/93900505/140726950-d066240d-ed01-4906-bf74-c10378afe21d.png)

- Add TNS name resolver to 3 pages:
  - Send token (`src/post/hooks/wallet/useSend.ts`)
  - Community Pool Spend Proposal (`src/post/hooks/gov/usePropose.ts`)
  - Sign-in with address (`src/hooks/auth/useSignInWithAddress.ts`)
- Since the validation function in `useForm` only supports synchronous function, TNS name resolution logic is done outside the `useForm` scope. Hence, `useTns` hook is introduced.
- Add TNS name error `This name has not yet been configured` and other languages translation.

## Test cases
- Fill in `blossom.ust`, it should resolve to an address `terra1...9hthwzp` (Like above image)
- Fill in `axfkcsnjr.ust`, it should show `This name has not yet been configured` validation error message.

![Screen_Shot_2564-11-08_at_17 30 24](https://user-images.githubusercontent.com/93900505/140726537-2be602c8-c9c8-44cd-af6b-61d35d89629a.png)


## Expected Behavior
- Send token
![station-wallet](https://user-images.githubusercontent.com/93900505/140726614-94ae6c4c-7580-4c91-bfe5-434e8d81c488.gif)

- Community Pool Spend Proposal
![station-gov](https://user-images.githubusercontent.com/93900505/140726686-57af0640-9c2f-4620-b5f6-945f75b125fc.gif)

- Sign-in with address
![station-connect](https://user-images.githubusercontent.com/93900505/140726435-bbfa5e41-6fdf-42d1-ac6f-8859c4e14a6c.gif)

