### PR TITLE
fix: Check to see if `to` is a native Terra asset.

### DIFF
--- a/src/post/hooks/wallet/routeswap.ts
+++ b/src/post/hooks/wallet/routeswap.ts
@@ -28,7 +28,7 @@ export const isMarketAvailable = ({ from, to }: SwapParams) =>
 export const findPair = ({ from, to }: SwapParams, pairs?: Pairs) => {
   if (!pairs) return
 
-  const shouldBurnLuna = from === 'uluna' && is.nativeTerra(from)
+  const shouldBurnLuna = from === 'uluna' && is.nativeTerra(to)
   const pair = Object.entries(pairs).find(([, tokens]) =>
     [from, to].every((token) => tokens.includes(token))
   )?.[0]


### PR DESCRIPTION
When determining if we should be burning luna or not on swaps, I noticed we were checking `from` twice. 