### PR TITLE
Add LunaPunks svg image_data custom fix

### DIFF
--- a/src/pages/nft/NFTItem.tsx
+++ b/src/pages/nft/NFTItem.tsx
@@ -7,6 +7,7 @@ import { NFTContract } from '../../types'
 import Send from './Send'
 import View from './View'
 import styles from './NFTItem.module.scss'
+import { runCustomImageDataParsers } from '../../utils/nftImageDataParser'
 
 interface Props extends NFTContract {
   tokenId: string
@@ -17,17 +18,6 @@ const NFTItem = (item: Props) => {
   const { modal } = useApp()
   const { data } = useNFTQuery(contract, tokenId)
 
-  const checkLunaPunkImage = (imageData: string | undefined) => {
-    const LUNAPUNKS_CONTRACT = 'terra1qfy2nfr0zh70jyr3h4ns9rzqx4fl8rxpf09ytv'
-    if (contract !== LUNAPUNKS_CONTRACT || !imageData) return
-    const svgSplitString = imageData.split('viewBox')
-    const svg = svgSplitString[0].concat(
-      "xmlns='http://www.w3.org/2000/svg' viewBox",
-      svgSplitString[1]
-    )
-    return 'data:image/svg+xml,'.concat(svg)
-  }
-
   const render = () => {
     if (!data) return null
 
@@ -36,7 +26,10 @@ const NFTItem = (item: Props) => {
 
     const imgUrl = image?.startsWith('ipfs://')
       ? image?.replace('ipfs://', 'https://ipfs.io/ipfs/')
-      : image ?? checkLunaPunkImage(image_data)
+      : image ??
+        runCustomImageDataParsers(image_data, contract) ??
+        image_data ??
+        ''
 
     const icon = imgUrl ? (
       <img

--- a/src/pages/nft/NFTItem.tsx
+++ b/src/pages/nft/NFTItem.tsx
@@ -17,16 +17,26 @@ const NFTItem = (item: Props) => {
   const { modal } = useApp()
   const { data } = useNFTQuery(contract, tokenId)
 
+  const checkLunaPunkImage = (imageData: string | undefined) => {
+    const LUNAPUNKS_CONTRACT = 'terra1qfy2nfr0zh70jyr3h4ns9rzqx4fl8rxpf09ytv'
+    if (contract !== LUNAPUNKS_CONTRACT || !imageData) return
+    const svgSplitString = imageData.split('viewBox')
+    const svg = svgSplitString[0].concat(
+      "xmlns='http://www.w3.org/2000/svg' viewBox",
+      svgSplitString[1]
+    )
+    return 'data:image/svg+xml,'.concat(svg)
+  }
+
   const render = () => {
     if (!data) return null
 
     const { extension } = data
-    const image = extension?.image
-    const name = extension?.name
+    const { name, image, image_data } = extension
 
     const imgUrl = image?.startsWith('ipfs://')
       ? image?.replace('ipfs://', 'https://ipfs.io/ipfs/')
-      : image
+      : image ?? checkLunaPunkImage(image_data)
 
     const icon = imgUrl ? (
       <img

--- a/src/types/pages/nft.ts
+++ b/src/types/pages/nft.ts
@@ -22,4 +22,5 @@ export interface Extension {
   name?: string
   description?: string
   image?: string
+  image_data?: string
 }

--- a/src/utils/nftImageDataParser.test.ts
+++ b/src/utils/nftImageDataParser.test.ts
@@ -1,0 +1,29 @@
+import { runCustomImageDataParsers } from './nftImageDataParser'
+
+describe('nftImageDataParser', () => {
+  describe('runCustomImageDataParsers', () => {
+    const mockContract = 'terra1mockcontractaddress'
+    const lunaPunkContract = 'terra1qfy2nfr0zh70jyr3h4ns9rzqx4fl8rxpf09ytv'
+    const imageData = '<svg></svg>'
+    it('should return undefined if empty values returned', () => {
+      const parsedImage = runCustomImageDataParsers()
+      console.log(parsedImage)
+      expect(parsedImage).toBeUndefined()
+    })
+    it('should return undefined if image data has value but empty contract', () => {
+      const parsedImage = runCustomImageDataParsers(imageData)
+      console.log(parsedImage)
+      expect(parsedImage).toBeUndefined()
+    })
+    it('should return undefined if image data has value but not part of custom parser contract', () => {
+      const parsedImage = runCustomImageDataParsers(imageData, mockContract)
+      console.log(parsedImage)
+      expect(parsedImage).toBeUndefined()
+    })
+    it('should return run custom parser if parsed LunaPunk contract', () => {
+      const parsedImage = runCustomImageDataParsers(imageData, lunaPunkContract)
+      console.log(parsedImage)
+      expect(parsedImage).not.toBeUndefined()
+    })
+  })
+})

--- a/src/utils/nftImageDataParser.test.ts
+++ b/src/utils/nftImageDataParser.test.ts
@@ -6,24 +6,18 @@ describe('nftImageDataParser', () => {
     const lunaPunkContract = 'terra1qfy2nfr0zh70jyr3h4ns9rzqx4fl8rxpf09ytv'
     const imageData = '<svg></svg>'
     it('should return undefined if empty values returned', () => {
-      const parsedImage = runCustomImageDataParsers()
-      console.log(parsedImage)
-      expect(parsedImage).toBeUndefined()
+      expect(runCustomImageDataParsers()).toBeUndefined()
     })
     it('should return undefined if image data has value but empty contract', () => {
-      const parsedImage = runCustomImageDataParsers(imageData)
-      console.log(parsedImage)
-      expect(parsedImage).toBeUndefined()
+      expect(runCustomImageDataParsers(imageData)).toBeUndefined()
     })
     it('should return undefined if image data has value but not part of custom parser contract', () => {
-      const parsedImage = runCustomImageDataParsers(imageData, mockContract)
-      console.log(parsedImage)
-      expect(parsedImage).toBeUndefined()
+      expect(runCustomImageDataParsers(imageData, mockContract)).toBeUndefined()
     })
     it('should return run custom parser if parsed LunaPunk contract', () => {
-      const parsedImage = runCustomImageDataParsers(imageData, lunaPunkContract)
-      console.log(parsedImage)
-      expect(parsedImage).not.toBeUndefined()
+      expect(
+        runCustomImageDataParsers(imageData, lunaPunkContract)
+      ).not.toBeUndefined()
     })
   })
 })

--- a/src/utils/nftImageDataParser.ts
+++ b/src/utils/nftImageDataParser.ts
@@ -1,0 +1,28 @@
+// Custom image parse handling. Advisable to whitelist individual contract after testing due to security of external source
+
+// LunaPunks custom parser
+const checkLunaPunkImage = (imageData?: string, contract?: string) => {
+  const LUNAPUNKS_CONTRACT = 'terra1qfy2nfr0zh70jyr3h4ns9rzqx4fl8rxpf09ytv'
+  if (contract !== LUNAPUNKS_CONTRACT || !imageData) return
+  const svgSplitString = imageData.split('viewBox')
+  const svg = svgSplitString[0].concat(
+    "xmlns='http://www.w3.org/2000/svg' viewBox",
+    svgSplitString[1]
+  )
+  return 'data:image/svg+xml,'.concat(svg)
+}
+
+const customImageDataParsers = [checkLunaPunkImage]
+
+// Main runner to parse through various custom parsers.
+export const runCustomImageDataParsers = (
+  imageData?: string,
+  contract?: string
+) => {
+  let final
+  customImageDataParsers.forEach((parser) => {
+    const parsed = parser(imageData, contract)
+    if (parsed) final = parsed
+  })
+  return final
+}


### PR DESCRIPTION
LunaPunks image data is onchain, and requires some custom mangling to show in the station app.

Tried to make it as generalised as possible, however realised that the contract SVG image might not been perfect to use with <img> tags, the original intent was to draw unto canvas technologies.

We managed to add a custom fix, hope this is mergeable, let me know if there is anything we can do to make it better for Terra Station repo. 

<img width="501" alt="Screenshot 2021-12-08 at 12 16 21 AM" src="https://user-images.githubusercontent.com/1845263/145065842-94dc553b-f095-4012-a789-9f29cf32f2c3.png">


