### PR TITLE
Validator sorting uptime

### DIFF
--- a/src/pages/hooks/staking/useStaking.ts
+++ b/src/pages/hooks/staking/useStaking.ts
@@ -210,6 +210,8 @@ export default (initialSort?: { by: string; sort?: string }): StakingPage => {
   const [asc, setAsc] = useState<boolean>(initialAsc)
   const { prop, isString } = sorter
 
+  const minSortedUptimeDiff = 0.001
+
   const renderValidators = (staking: StakingData): StakingUI => {
     const { validators, delegationTotal = '0', undelegations } = staking
     const undelegationTotal = calcUndelegationTotal(undelegations)
@@ -229,7 +231,14 @@ export default (initialSort?: { by: string; sort?: string }): StakingPage => {
         const b: string = String(path(prop.split('.'), validatorB) || 0)
         const c = asc ? 1 : -1
         const compareString = c * (a.toLowerCase() > b.toLowerCase() ? 1 : -1)
-        const compareNumber = c * (gt(a, b) ? 1 : -1)
+        const compareNumber =
+          c *
+          (Math.abs(toNumber(minus(a, b))) < minSortedUptimeDiff
+            ? Math.random() - 0.5
+            : gt(a, b)
+            ? 1
+            : -1)
+
         return a === b ? 0 : isString ? compareString : compareNumber
       })
       .sort(({ status: a }, { status: b }) => {

--- a/src/pages/hooks/staking/useStaking.ts
+++ b/src/pages/hooks/staking/useStaking.ts
@@ -210,7 +210,7 @@ export default (initialSort?: { by: string; sort?: string }): StakingPage => {
   const [asc, setAsc] = useState<boolean>(initialAsc)
   const { prop, isString } = sorter
 
-  const minSortedUptimeDiff = 0.001
+  const minSortedUptimeDiff = 0.0001
 
   const renderValidators = (staking: StakingData): StakingUI => {
     const { validators, delegationTotal = '0', undelegations } = staking

--- a/src/pages/hooks/staking/useValidatorItem.ts
+++ b/src/pages/hooks/staking/useValidatorItem.ts
@@ -75,7 +75,7 @@ export default (): ((v: ValidatorData, params?: Params) => ValidatorUI) => {
       uptime: {
         title: t('Page:Staking:Uptime'),
         desc: t('Page:Staking:Last 10k blocks'),
-        percent: percent(upTime, 0),
+        percent: percent(upTime, 2),
       },
 
       myDelegations: Object.assign(


### PR DESCRIPTION
Due to the decentralization purpose, I propose random validator sorting with almost the same uptime and more precision for uptime percent.
Check it here: https://autism-staking-station.vercel.app/staking.
Discussion in validator's discord: https://discord.com/channels/566086600560214026/566126867686621185/917807464840314891