### PR TITLE
Use Cloudflare IPFS gateway for NFT images. 

### DIFF
--- a/src/pages/nft/NFTItem.tsx
+++ b/src/pages/nft/NFTItem.tsx
@@ -25,7 +25,7 @@ const NFTItem = (item: Props) => {
     const name = extension?.name
 
     const imgUrl = image?.startsWith('ipfs://')
-      ? image?.replace('ipfs://', 'https://ipfs.io/ipfs/')
+      ? image?.replace('ipfs://', 'https://cloudflare-ipfs.com/ipfs/')
       : image
 
     const icon = imgUrl ? (

--- a/src/types/pages/nft.ts
+++ b/src/types/pages/nft.ts
@@ -10,6 +10,7 @@ export interface NFTContract {
 export interface NFTMarketplace {
   link: string
   name: string
+  icon?: string
 }
 
 export type NFTContracts = Dictionary<NFTContract>


### PR DESCRIPTION
I've had issues with my NFT images not fully loading in Station. In my experience the Cloudflare gateway is much quicker, and images tend to load better. You can test this yourself with the two links below: 

[IPFS Gateway](https://ipfs.io/ipfs/QmRNEHqvbrXdVtxR8hLDvqmrT2cgPNJnX4uab3oqbXUusM)

[Cloudflare Gateway](https://cloudflare-ipfs.com/ipfs/QmRNEHqvbrXdVtxR8hLDvqmrT2cgPNJnX4uab3oqbXUusM)

I've also added an optional icon to the NFTMarketplace typedef. This is already in-use by the assets repo: 

https://github.com/terra-money/assets/blob/master/cw721/marketplace.js#L9 